### PR TITLE
helm: Fix image path

### DIFF
--- a/deploy/helm/quadra/values.yaml
+++ b/deploy/helm/quadra/values.yaml
@@ -1,7 +1,7 @@
 podName: netint-pod
 namespace: kube-system
 serviceAccountName: netint-admin
-image: netint/quadra_ubuntu-24-04_ffmpeg:latest
+image: netint/quadra_ubuntu-24.04_ffmpeg:latest
 securityContext:
   privileged: false
 containerPort: 80


### PR DESCRIPTION
Fixing image path since netint/quadra_ubuntu-24-04_ffmpeg:latest does not exist.